### PR TITLE
Adding refresh limit capability. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ ads slows down your page.
 For example, one ad might be `placement="upper right"`, while another might be
 `placement="lower left"`.
 
+* `refreshLimit=N` Limit refreshing to `N` times. For example, setting to 5 would stop refreshing after the 5th time.
+
 * `tracing=true`: Turn on `Ember.Logger.log` tracing.
 
 Additionally, if you want to use GPT's `setTargeting` function to serve targeted

--- a/addon/components/google-publisher-tag.js
+++ b/addon/components/google-publisher-tag.js
@@ -141,32 +141,30 @@ export default Component.extend(InViewportMixin, {
         this.doRefresh();
     }).restartable(),
 
-    canRefresh() {
-      let isWithinLimits = get(this, 'refreshLimit') >= get(this, 'refreshCount');
-      return this.isRefreshLimited() && isWithinLimits;
-    },
-
     doRefresh() {
 
-        if (this.canRefresh()) {
+        let refreshLimit   = get(this, 'refreshLimit');
+        let refreshCount   = get(this, 'refreshCount');
+        let isWithinLimits = refreshLimit >= get(this, 'refreshCount');
+        let canRefresh     = this.isRefreshLimited() && isWithinLimits;
+        let debugMsg       = `refresh called ${refreshCount} of ${refreshLimit} times`;
 
-          // log helpful data when refresh is limited
-          if (this.isRefreshLimited()) {
-            this.trace(`refreshed ${get(this, 'refreshCount')} of ${get(this, 'refreshLimit')} times`);
-          }
-
-          let googletag = window.googletag;
-          googletag.cmd.push( () => {
-            let slot = get(this, 'slot');
-            this.trace('refreshing now');
-            this.addTargeting(slot);
-            googletag.pubads().refresh([slot]);
-            this.waitForRefresh();
-          });
-
-        } else {
-          this.trace('can not refresh slot');
+        if (!canRefresh) {
+          return this.trace('Could not refresh :: ', debugMsg);
         }
+
+        if (this.isRefreshLimited()) {
+          this.trace(debugMsg);
+        }
+
+        let googletag = window.googletag;
+        googletag.cmd.push( () => {
+          let slot = get(this, 'slot');
+          this.trace('refreshing now');
+          this.addTargeting(slot);
+          googletag.pubads().refresh([slot]);
+          this.waitForRefresh();
+        });
     },
 
     isRefreshLimited() {
@@ -175,6 +173,7 @@ export default Component.extend(InViewportMixin, {
 
     didEnterViewport() {
       this.trace('entered viewport');
+
       this.initAd();
       if (get(this, 'isRefreshOverdue')) {
         this.doRefresh();


### PR DESCRIPTION
Setting a `refreshLimit` will cause refresh to stop after x refreshes.

```
  // The following ad will refresh 10 times every 30 seconds, and then stop.
  {{google-publisher-tag
    tracing=1
    adId="/6355419/Travel/Europe/France/Paris"
    width=300
    height=250
    refresh=30
    refreshLimit=10
  }}
```
