### PR TITLE
update ember-get-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-concurrency": "^0.7.8",
-    "ember-get-config": "0.1.11",
+    "ember-get-config": "^0.2.0",
     "ember-in-viewport": "^2.1.0"
   },
   "ember-addon": {


### PR DESCRIPTION
This gets rid of the [incorrect](https://github.com/null-null-null/ember-get-config/pull/12) build deprecation from the console.

```
DEPRECATION: `ember-get-config` previously recommended reinvoking the `included` hook, but that is no longer recommended. Please remove the additional invocation.
```